### PR TITLE
Possible crash to assign tableView properties before calling `showTable`

### DIFF
--- a/UIDropDown/UIDropDown.swift
+++ b/UIDropDown/UIDropDown.swift
@@ -362,7 +362,7 @@ extension UIDropDown: UITableViewDelegate {
             hideTable()
         }
         
-        privatedidSelect("\(self.options[indexPath.row])", indexPath/.row!)
+        privatedidSelect("\(self.options[indexPath.row])", indexPath.row!)
     }
 }
 

--- a/UIDropDown/UIDropDown.swift
+++ b/UIDropDown/UIDropDown.swift
@@ -362,7 +362,7 @@ extension UIDropDown: UITableViewDelegate {
             hideTable()
         }
         
-        privatedidSelect("\(self.options[indexPath.row])", selectedIndex!)
+        privatedidSelect("\(self.options[indexPath.row])", indexPath/.row!)
     }
 }
 

--- a/UIDropDown/UIDropDown.swift
+++ b/UIDropDown/UIDropDown.swift
@@ -160,16 +160,6 @@ public class UIDropDown: UIControl {
         self.layer.borderWidth = borderWidth
         self.layer.borderColor = borderColor.cgColor
         self.addTarget(self, action: #selector(touch), for: .touchUpInside)
-    }
-    
-    @objc fileprivate func touch() {
-        isSelected = !isSelected
-        isSelected ? showTable() : hideTable()
-    }
-    
-    fileprivate func showTable() {
-        
-        privateTableWillAppear()
         
         table = UITableView(frame: CGRect(x: self.frame.minX,
                                           y: self.frame.minY,
@@ -182,7 +172,21 @@ public class UIDropDown: UIControl {
         table.layer.borderWidth = optionsBorderWidth
         table.layer.borderColor = optionsBorderColor.cgColor
         table.rowHeight = rowHeight ?? table.rowHeight
-        self.superview?.insertSubview(table, belowSubview: self)
+    }
+    
+    @objc fileprivate func touch() {
+        isSelected = !isSelected
+        isSelected ? showTable() : hideTable()
+    }
+    
+    fileprivate func showTable() {
+        
+        privateTableWillAppear()
+        
+        self.table.isHidden = false
+        if (self.table.superview) == nil {
+            self.superview?.insertSubview(table, belowSubview: self)
+        }
         
         switch animationType {
         case .Default:
@@ -271,7 +275,7 @@ public class UIDropDown: UIControl {
                             self.arrow.position = .down
                 },
                            completion: { (didFinish) -> Void in
-                            self.table.removeFromSuperview()
+                            self.table.isHidden = true
                             self.isSelected = false
                             self.privateTableDidDisappear()
             })
@@ -292,7 +296,7 @@ public class UIDropDown: UIControl {
                             self.arrow.position = .down
                 },
                            completion: { (didFinish) -> Void in
-                            self.table.removeFromSuperview()
+                            self.table.isHidden = true
                             self.isSelected = false
                             self.privateTableDidDisappear()
             })

--- a/UIDropDown/UIDropDown.swift
+++ b/UIDropDown/UIDropDown.swift
@@ -358,19 +358,6 @@ extension UIDropDown: UITableViewDataSource {
 
 extension UIDropDown: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
-        selectedIndex = (indexPath as NSIndexPath).row
-        
-        title.alpha = 0.0
-        title.text = "\(self.options[(indexPath as NSIndexPath).row])"
-        
-        UIView.animate(withDuration: 0.6,
-                       animations: { () -> Void in
-                        self.title.alpha = 1.0
-        })
-        
-        tableView.reloadData()
-        
         if hideOptionsWhenSelect {
             hideTable()
         }

--- a/UIDropDown/UIDropDown.swift
+++ b/UIDropDown/UIDropDown.swift
@@ -362,7 +362,7 @@ extension UIDropDown: UITableViewDelegate {
             hideTable()
         }
         
-        privatedidSelect("\(self.options[indexPath.row])", indexPath.row!)
+        privatedidSelect("\(self.options[indexPath.row])", indexPath.row)
     }
 }
 


### PR DESCRIPTION
First of all, thank you for providing great dropdown API. I have noticed that the tableview being allocated and inserted every time `showTable()` being called. Inserting view could be potentially heavy lifting, how about allocate instance once in the `setup()` and use the UIView's `hide` property? Also, by fixing this, API callee can access tableview's properties (currently bug) such as background color, layer border width, etc before even it being displays.